### PR TITLE
upgrade checkout v4 and setup-python v5

### DIFF
--- a/.github/workflows/bandit-security.yml
+++ b/.github/workflows/bandit-security.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
 

--- a/.github/workflows/packer-ami-build.yml
+++ b/.github/workflows/packer-ami-build.yml
@@ -25,10 +25,10 @@ jobs:
             --health-retries 5
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.9'
     

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.9'
     


### PR DESCRIPTION
Upgrades:
```
- uses: actions/checkout@v4
- uses: actions/setup-python@v5
```