### PR TITLE
add execstartpre condition for .env file

### DIFF
--- a/webapp-systemd.service
+++ b/webapp-systemd.service
@@ -7,6 +7,7 @@ Type=simple
 User=csye6225
 Group=csye6225
 WorkingDirectory=/opt/webapp
+ExecStartPre=/bin/bash -c 'if [ ! -f /opt/webapp/.env ]; then echo ".env file not found" >&2; exit 1; fi'
 ExecStart=/usr/bin/python3 /opt/webapp/app/app.py
 Restart=always
 RestartSec=3


### PR DESCRIPTION
Add `ExecStartPre` condition to check for `.env` file within `/opt/webapp` folder before starting service and running app